### PR TITLE
MIMIR-530 : allow disabled items in dropdown

### DIFF
--- a/src/components/Dropdown/_dropdown.scss
+++ b/src/components/Dropdown/_dropdown.scss
@@ -99,6 +99,18 @@
           z-index: 2;
         }
 
+        &:disabled {
+          background: $ssb-white;
+          color: $ssb-dark-2;
+          cursor: not-allowed;
+          font-weight: normal;
+
+          &:hover, &:focus {
+            text-decoration: none;
+            background: $ssb-dark-3;
+          }
+        }
+
         &.selected {
           background: $ssb-green-4;
           color: $ssb-white;

--- a/src/components/Dropdown/_dropdown.scss
+++ b/src/components/Dropdown/_dropdown.scss
@@ -107,7 +107,7 @@
 
           &:hover, &:focus {
             text-decoration: none;
-            background: $ssb-dark-3;
+            background: none;
           }
         }
 

--- a/src/components/Dropdown/dropdown.story.jsx
+++ b/src/components/Dropdown/dropdown.story.jsx
@@ -19,6 +19,7 @@ const items = [
 	}, {
 		title: 'Banan',
 		id: 'item5',
+		disabled: true,
 	}, {
 		title: 'Appelsin',
 		id: 'item6',

--- a/src/components/Dropdown/dropdown.test.jsx
+++ b/src/components/Dropdown/dropdown.test.jsx
@@ -9,6 +9,7 @@ const items = [
 	}, {
 		title: 'Rainbows',
 		id: 'item2',
+		disabled: true,
 	}, {
 		title: 'Ocean',
 		id: 'item3',
@@ -44,6 +45,11 @@ describe('Dropdown component', () => {
 		const wrapper = shallow(<Dropdown header="Menu header" items={items} open />);
 		wrapper.find('.list-of-options').find('button').first().simulate('click');
 		expect(wrapper.find('input').props().placeholder).toEqual('Apples');
+	});
+
+	test('Verify disabled item', () => {
+		const wrapper = shallow(<Dropdown header="Menu header" items={items} open />);
+		expect(wrapper.find('.list-of-options').find('button').find({ id: 'item2' }).prop('disabled')).toBe(true);
 	});
 
 	test('Triggers filter function on search', () => {

--- a/src/components/Dropdown/index.jsx
+++ b/src/components/Dropdown/index.jsx
@@ -64,6 +64,7 @@ const Dropdown = ({
 					<div className="list-of-options">
 						{availableOptions.map(it => (
 							<button
+								disabled={it.disabled}
 								className={`option-list-element${selectedOption.id === it.id ? ' selected' : ''}`}
 								key={it.id}
 								onClick={() => handleSelection(it)}
@@ -93,6 +94,7 @@ Dropdown.propTypes = {
 	items: PropTypes.arrayOf(PropTypes.shape({
 		title: PropTypes.string,
 		id: PropTypes.string,
+		disabled: PropTypes.boolean,
 	})),
 	onSelect: PropTypes.func,
 	open: PropTypes.bool,


### PR DESCRIPTION
Adding `disabled: true` to the an item in the `items` prop of `Dropdown` renders a disabled (hence un-selectable) row in the dropdown list. 
```
const items = [
  { id: 'item1', title: 'Ocean' },
  ...
  { id: 'item2', title: 'Banan', disabled: true },
  { id: 'item3', title: 'Applesin' },
];

<Dropdown items={items} />
```

<img width="369" alt="dd-disabled" src="https://user-images.githubusercontent.com/62878049/78134103-e3a0dd00-741f-11ea-9b22-2bf4dd39e168.png">
