### PR TITLE
Addet aria-label to link

### DIFF
--- a/src/components/Link/README.md
+++ b/src/components/Link/README.md
@@ -61,6 +61,7 @@ Available props:
 
 | Name       | Type           | Description  |
 | ---------- | ------------- | ----- |
+| ariaLabel | string | Defines a string value that describe the link if no link text |
 | children   | Required node | Something that renders to wrap the link around |
 | className   | string | Optional container class|
 | href | Required string| Destination for navigation |

--- a/src/components/Link/index.jsx
+++ b/src/components/Link/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Link = ({
-	children, className, href, icon, isExternal, linkType, negative, tabIndex,
+	ariaLabel, children, className, href, icon, isExternal, linkType, negative, tabIndex,
 }) => {
 	const classNames = `ssb-link${linkType ? ` ${linkType}` : ''}${negative ? ' negative' : ''}${icon ? ' with-icon' : ''}${className ? ` ${className}` : ''}`;
 
@@ -13,8 +13,9 @@ const Link = ({
 			target={isExternal ? '_blank' : ''}
 			rel={isExternal ? 'noopener noreferrer' : ''}
 			tabIndex={tabIndex}
+			aria-label={ariaLabel}
 		>{icon && <div className="icon-wrapper">{icon}</div>}
-			<span className="link-text">{children}</span>
+			{children && <span className="link-text">{children}</span>}
 		</a>
 	);
 };
@@ -26,6 +27,7 @@ Link.defaultProps = {
 };
 
 Link.propTypes = {
+	ariaLabel: PropTypes.string,
 	children: PropTypes.node,
 	className: PropTypes.string,
 	href: PropTypes.string.isRequired,


### PR DESCRIPTION
Got accessibility error when using link without text, added aria-label as a prop to avoid this

MIMIR-508