### PR TITLE
MIMIR-658 : support rows and cols in textarea component

### DIFF
--- a/src/components/TextArea/TextArea.story.jsx
+++ b/src/components/TextArea/TextArea.story.jsx
@@ -28,4 +28,15 @@ storiesOf('TextArea', module).addDecorator(centered)
 			<TextArea negative label="Label" handleChange={handleChange} value={someValue} />
 			<TextArea negative label="Label" handleChange={handleChange} value={someValue} error errorMessage="You made a mistake, fool! What the hell" />
 		</div>
+	))
+	.add('Rows/Cols', () => (
+		<div>
+			<TextArea
+				label="rows cols"
+				rows={20}
+				cols={50}
+				value={someValue}
+				handleChange={handleChange}
+			/>
+		</div>
 	));

--- a/src/components/TextArea/__snapshots__/textArea.test.jsx.snap
+++ b/src/components/TextArea/__snapshots__/textArea.test.jsx.snap
@@ -8,9 +8,11 @@ exports[`Input component Matches the snapshot 1`] = `
     className="text-area-wrapper"
   >
     <textarea
+      cols={10}
       disabled={false}
       id={1}
       onChange={[Function]}
+      rows={5}
     />
   </div>
 </div>

--- a/src/components/TextArea/_text-area.scss
+++ b/src/components/TextArea/_text-area.scss
@@ -25,7 +25,6 @@
     box-sizing: border-box;
     color: $ssb-dark-6;
     font-size: 16px;
-    height: $input-field-height;
     line-height: 1.25;
     min-height: $input-field-height;
     min-width: 200px;

--- a/src/components/TextArea/index.jsx
+++ b/src/components/TextArea/index.jsx
@@ -5,7 +5,7 @@ import InputError from '../InputError';
 
 const TextArea = ({
 	ariaLabel, className, disabled, error, errorMessage, handleChange, id, label, negative, placeholder, value,
-	rows, cols
+	rows, cols,
 }) => {
 	const [inputValue, setValue] = useState(value);
 	const inputId = id || uuid();
@@ -57,7 +57,7 @@ TextArea.propTypes = {
 	placeholder: PropTypes.string,
 	value: PropTypes.string,
 	rows: PropTypes.number,
-	cols: PropTypes.number
+	cols: PropTypes.number,
 };
 
 export default TextArea;

--- a/src/components/TextArea/index.jsx
+++ b/src/components/TextArea/index.jsx
@@ -5,6 +5,7 @@ import InputError from '../InputError';
 
 const TextArea = ({
 	ariaLabel, className, disabled, error, errorMessage, handleChange, id, label, negative, placeholder, value,
+	rows, cols
 }) => {
 	const [inputValue, setValue] = useState(value);
 	const inputId = id || uuid();
@@ -24,6 +25,8 @@ const TextArea = ({
 					onChange={e => handleInputChange(e)}
 					placeholder={placeholder}
 					aria-label={ariaLabel}
+					rows={rows}
+					cols={cols}
 				/>
 			</div>
 			{error && (errorMessage && (
@@ -53,6 +56,8 @@ TextArea.propTypes = {
 	negative: PropTypes.bool,
 	placeholder: PropTypes.string,
 	value: PropTypes.string,
+	rows: PropTypes.number,
+	cols: PropTypes.number
 };
 
 export default TextArea;

--- a/src/components/TextArea/textArea.test.jsx
+++ b/src/components/TextArea/textArea.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {shallow} from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import TextArea from './index';
 import InputError from '../InputError';
 
@@ -7,7 +7,7 @@ jest.mock('uuid/v4', () => jest.fn(() => 1));
 
 describe('Input component', () => {
 	test('Matches the snapshot', () => {
-		const wrapper = shallow(<TextArea>Input</TextArea>);
+		const wrapper = shallow(<TextArea rows={5} cols={10}>Input</TextArea>);
 		expect(wrapper).toMatchSnapshot();
 	});
 
@@ -29,6 +29,14 @@ describe('Input component', () => {
 			target: { value: 'hello' }
 		});
 		expect(handleChange).toBeCalledWith('hello');
+	});
+
+	test('respects rows and cols', () => {
+		const wrapper = mount(<TextArea rows={5} cols={25} />);
+		const textArea = wrapper.find('textarea');
+
+		expect(textArea.props().rows).toEqual(5);
+		expect(textArea.props().cols).toEqual(25);
 	});
 
 	test('Renders an error message on error', () => {


### PR DESCRIPTION
- add `rows` and `cols` props 
- remove `height` from styling (which overrides the number of rows the `textarea` component would otherwise display properly)