### PR TITLE
Adds hyphens: auto rule to title component

### DIFF
--- a/src/components/Title/_title.scss
+++ b/src/components/Title/_title.scss
@@ -1,13 +1,13 @@
 .ssb-title {
   color: $ssb-dark-6;
   margin-top: 0;
+  hyphens: auto;
 
   &.negative {
     color: $ssb-white;
   }
 
   @at-root {
-
     h1#{&} {
       @include roboto-condenced;
       font-size: 56px;
@@ -51,7 +51,6 @@
     }
 
     @media #{$mobile} {
-
       h1#{&} {
         font-size: 44px;
         line-height: 56px;

--- a/src/components/Title/title.story.jsx
+++ b/src/components/Title/title.story.jsx
@@ -14,10 +14,11 @@ storiesOf('Title', module)
     </div>
   ))
   .add('Long words', () => (
-    <div>
+    <div style={{ maxWidth: '500px' }}>
       <p>
-        On screens with high magnification, long words would sometimes not
-        break, but flow outside the viewport. The{' '}
+        When long titles run out of space, long words would not break to the
+        next line, but flow outside the viewport. This is an example of how we
+        fix this with <code>hyphens: auto;</code>
       </p>
       <Title size={1}>
         This is a h1 title and contains the Very Long Word

--- a/src/components/Title/title.story.jsx
+++ b/src/components/Title/title.story.jsx
@@ -3,13 +3,45 @@ import { storiesOf } from '@storybook/react';
 import Title from './index';
 
 storiesOf('Title', module)
-	.add('Default', () => (
-		<div>
-			<Title size={1}>This is a h1 title</Title>
-			<Title size={2}>This is a h2 title</Title>
-			<Title size={3}>This is a h3 title</Title>
-			<Title size={4}>This is a h4 title</Title>
-			<Title size={5}>This is a h5 title</Title>
-			<Title size={6}>This is a h6 title</Title>
-		</div>
-	));
+  .add('Default', () => (
+    <div>
+      <Title size={1}>This is a h1 title</Title>
+      <Title size={2}>This is a h2 title</Title>
+      <Title size={3}>This is a h3 title</Title>
+      <Title size={4}>This is a h4 title</Title>
+      <Title size={5}>This is a h5 title</Title>
+      <Title size={6}>This is a h6 title</Title>
+    </div>
+  ))
+  .add('Long words', () => (
+    <div>
+      <p>
+        On screens with high magnification, long words would sometimes not
+        break, but flow outside the viewport. The{' '}
+      </p>
+      <Title size={1}>
+        This is a h1 title and contains the Very Long Word
+        antidisestablishmentarianism
+      </Title>
+      <Title size={2}>
+        This is a h2 title and contains the Very Long Word
+        pseudopseudohypoparathyroidism
+      </Title>
+      <Title size={3}>
+        This is a h3 title and contains the Very Long Word
+        supercalifragilisticexpialidocious
+      </Title>
+      <Title size={4}>
+        This is a h4 title and contains the Very Long Word
+        pneumonoultramicroscopicsilicovolcanoconiosis
+      </Title>
+      <Title size={5}>
+        This is a h5 title and contains the Very Long Word
+        Gammaracanthuskytodermogammarus loricatobaicalensis
+      </Title>
+      <Title size={6}>
+        This is a h6 title and contains the Very Long Word Austrocephalocereus
+        dolichospermaticus
+      </Title>
+    </div>
+  ));

--- a/src/components/Title/title.story.jsx
+++ b/src/components/Title/title.story.jsx
@@ -14,7 +14,7 @@ storiesOf('Title', module)
     </div>
   ))
   .add('Long words', () => (
-    <div style={{ maxWidth: '500px' }}>
+    <div style={{ maxWidth: '400px' }}>
       <p>
         When long titles run out of space, long words would not break to the
         next line, but flow outside the viewport. This is an example of how we
@@ -30,7 +30,7 @@ storiesOf('Title', module)
       </Title>
       <Title size={3}>
         This is a h3 title and contains the Very Long Word
-        supercalifragilisticexpialidocious
+        supercalifragilisticexpialidociousandwecanseethateventuallyitwillbreakontoanotherlinewithanicehypentoseparateonepartofthewordwithanother
       </Title>
       <Title size={4}>
         This is a h4 title and contains the Very Long Word


### PR DESCRIPTION
This ensures that long words are correctly divided, using hyphen and newline This is especially important when using high magnification in the browser, which is where the problem is usually encountered. MIMIR-1330