### PR TITLE
added check for actual npm release for tagging master branch

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           dry-run: false
-      - run: gh release create ${{ steps.publishNpm.outputs.version }} --generate-notes
+      - if: ${{ steps.publishNpm.outputs.type }}
+        run: gh release create ${{ steps.publishNpm.outputs.version }} --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Make sure master branch is tagged and new release in github created only when a new npm version actually is deployed.

See example: https://github.com/JS-DevTools/npm-publish#action-output