### PR TITLE
Remove environment in deploy action

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -27,7 +27,6 @@ jobs:
           CI: true
 
   publish:
-    environment: production
     needs: build
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Siden vi bruker info fra environment for å tracke deploy vil deploy fra komponent-biblioteket gjøre oversikten vanskelig i jira siden dette er en helt annen type deploy.