### PR TITLE
Re-render Input component on value prop change

### DIFF
--- a/src/components/Input/index.jsx
+++ b/src/components/Input/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, forwardRef } from 'react'
+import React, { useState, forwardRef, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { Search } from 'react-feather'
 import { useId } from '../../utils/useId'
@@ -11,29 +11,32 @@ const Input = forwardRef(
       ariaLabelWrapper,
       ariaLabel,
       ariaLabelledBy,
-      ariaLabelSearchButton,
+      ariaLabelSearchButton = 'search',
       name,
-      className,
-      disabled,
-      error,
+      className = '',
+      disabled = false,
+      error = false,
       errorMessage,
-      handleChange,
+      handleChange = () => {},
       id,
       label,
-      negative,
+      negative = false,
       placeholder,
-      searchField,
-      submitCallback,
-      type,
-      value,
-      onFocus,
-      onBlur,
+      searchField = false,
+      submitCallback = () => {},
+      type = 'text',
+      value = '',
+      onFocus = () => {},
+      onBlur = () => {},
       size,
     },
     ref
   ) => {
     const [inputValue, setValue] = useState(value)
     const inputId = id || useId()
+
+    useEffect(() => setValue(value), [value])
+
     const handleInputChange = (e) => {
       setValue(e.target.value)
       handleChange(e.target.value)
@@ -88,21 +91,6 @@ const Input = forwardRef(
     )
   }
 )
-
-Input.defaultProps = {
-  className: '',
-  disabled: false,
-  error: false,
-  handleChange: () => {},
-  onFocus: () => {},
-  onBlur: () => {},
-  negative: false,
-  searchField: false,
-  submitCallback: () => {},
-  type: 'text',
-  ariaLabelSearchButton: 'search',
-  value: '',
-}
 
 Input.propTypes = {
   role: PropTypes.string,

--- a/src/components/Input/input.story.jsx
+++ b/src/components/Input/input.story.jsx
@@ -32,19 +32,11 @@ export const SearchField = () => (
   </div>
 )
 
-SearchField.story = {
-  name: 'Search field',
-}
-
 export const WithValue = () => (
   <div style={{ width: '280px' }}>
     <Input label='Input field' value='Already filled' />
   </div>
 )
-
-WithValue.story = {
-  name: 'With value',
-}
 
 export const Disabled = () => (
   <div style={{ width: '280px' }}>
@@ -91,7 +83,3 @@ export const LargeInput = () => (
     <Input searchField size='lg' placeholder='Søk' />
   </div>
 )
-
-LargeInput.story = {
-  name: 'Large input',
-}


### PR DESCRIPTION
Re-implement the changes for Input from this PR: https://github.com/statisticsnorway/ssb-component-library/pull/1111

A temporary bug fix for stateful components (like Input) not re-rendering on state change e.g.:
- Forces a re-render of the Input component on value prop change
- Minor refactoring (deprecated defaultProps and storybook examples)