### PR TITLE
Remove overrides on webpack  and micromatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,10 +41,6 @@
   "peerDependencies": {
     "react": "^18.0.0"
   },
-  "overrides": {
-    "webpack": "~5.91.0",
-    "micromatch": "~4.0.6"
-  },
   "devDependencies": {
     "@babel/cli": "~7.24.1",
     "@babel/core": "~7.24.4",


### PR DESCRIPTION
Webpack is blocking dependabot and Micromatch is now patched in package-lock.json