### PR TITLE
Mim 1932 sr arrow keyfigure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statisticsnorway/ssb-component-library",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Component library for SSB (Statistics Norway)",
   "main": "lib/bundle.js",
   "scripts": {

--- a/src/components/Glossary/README.md
+++ b/src/components/Glossary/README.md
@@ -43,3 +43,4 @@ Available props:
 | className   | string          | Optional container class                 |
 | closeText   | string          | Close button text, default "Lukk"        |
 | explanation | required string | Text to be inside popup                  |
+| ariaLabel | string | Defines a string value that describes the glossary  |

--- a/src/components/Glossary/index.jsx
+++ b/src/components/Glossary/index.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useRef, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { BookOpen, XCircle } from 'react-feather'
 
-const Glossary = ({ explanation, children, className, closeText }) => {
+const Glossary = ({ explanation, children, className, closeText, ariaLabel }) => {
   const node = useRef()
   const [open, setOpen] = useState(false)
 
@@ -51,7 +51,7 @@ const Glossary = ({ explanation, children, className, closeText }) => {
         ref={node}
         onClick={() => setOpen(!open)}
         className='glossary-button'
-        aria-label={children}
+        aria-label={ariaLabel || children}
         aria-expanded={open ? 'true' : 'false'}
       >
         <span className='glossary-text-wrap'>{children}</span>
@@ -86,6 +86,7 @@ Glossary.propTypes = {
   className: PropTypes.string,
   closeText: PropTypes.string,
   explanation: PropTypes.string.isRequired,
+  ariaLabel: PropTypes.string,
 }
 
 export default Glossary

--- a/src/components/KeyFigures/README.md
+++ b/src/components/KeyFigures/README.md
@@ -134,7 +134,7 @@ Available props:
 
 | Name              | Type                                                                  | Description                                              |
 | ----------------- | --------------------------------------------------------------------- | -------------------------------------------------------- |
-| changes           | object (changeDirection [up, down or same], changeText, changePeriod) | Renders changetext with icon                             |
+| changes           | object (changeDirection [up, down or same], changeText, changePeriod, srChangeText) | Renders changetext with icon                             |
 | className         | string                                                                | Optional container class                                 |
 | icon              | node                                                                  | Renders an icon                                          |
 | number            | string or number                                                      | Large number to be displayed                             |

--- a/src/components/KeyFigures/__snapshots__/keyFigures.test.jsx.snap
+++ b/src/components/KeyFigures/__snapshots__/keyFigures.test.jsx.snap
@@ -215,7 +215,7 @@ exports[`KeyFigures component Renders Glossary 1`] = `
       >
         <button
           aria-expanded="false"
-          aria-label="[object Object]"
+          aria-label="Antall husholdninger"
           class="glossary-button"
         >
           <span
@@ -223,7 +223,9 @@ exports[`KeyFigures component Renders Glossary 1`] = `
           >
             <span
               class="kf-title"
-            />
+            >
+              Antall husholdninger
+            </span>
           </span>
           <svg
             aria-hidden="true"

--- a/src/components/KeyFigures/__snapshots__/keyFigures.test.jsx.snap
+++ b/src/components/KeyFigures/__snapshots__/keyFigures.test.jsx.snap
@@ -34,7 +34,7 @@ exports[`KeyFigures component Matches the snapshot 1`] = `
       >
         <button
           aria-expanded="false"
-          aria-label="[object Object]"
+          aria-label="Antall husholdninger"
           class="glossary-button"
         >
           <span
@@ -140,6 +140,19 @@ exports[`KeyFigures component Matches the snapshot 1`] = `
           husholdninger
         </span>
       </div>
+      <div
+        class="kf-changes"
+      >
+        <span
+          aria-hidden="false"
+          class="changes-text"
+        />
+         
+        <span
+          aria-hidden="false"
+          class="changes-periode"
+        />
+      </div>
     </div>
   </div>
 </DocumentFragment>
@@ -171,6 +184,19 @@ exports[`KeyFigures component Render green box variation 1`] = `
         </div>
         <span
           class="kf-title subtitle"
+        />
+      </div>
+      <div
+        class="kf-changes"
+      >
+        <span
+          aria-hidden="false"
+          class="changes-text"
+        />
+         
+        <span
+          aria-hidden="false"
+          class="changes-periode"
         />
       </div>
     </div>
@@ -287,6 +313,19 @@ exports[`KeyFigures component Renders Glossary 1`] = `
         </div>
         <span
           class="kf-title subtitle"
+        />
+      </div>
+      <div
+        class="kf-changes"
+      >
+        <span
+          aria-hidden="false"
+          class="changes-text"
+        />
+         
+        <span
+          aria-hidden="false"
+          class="changes-periode"
         />
       </div>
     </div>

--- a/src/components/KeyFigures/index.jsx
+++ b/src/components/KeyFigures/index.jsx
@@ -22,7 +22,7 @@ const KeyFigures = ({
     <div className={`ssb-key-figures ${size}${greenBox ? ' green-box' : ''}${className ? ` ${className}` : ''}`}>
       {icon && <div className={`kf-icon ${size}`}>{icon}</div>}
       <div>
-        {glossary ? (
+        {glossary && title ? (
           <Glossary explanation={glossary} ariaLabel={title}>
             <span className='kf-title'>{title}</span>
           </Glossary>

--- a/src/components/KeyFigures/index.jsx
+++ b/src/components/KeyFigures/index.jsx
@@ -5,52 +5,57 @@ import Number from '../Number'
 import Glossary from '../Glossary'
 
 const KeyFigures = ({
-  changes,
+  changes = {},
   className,
   icon,
   number,
   numberDescription,
-  noNumberText,
+  noNumberText = 'Tall ikke tilgjengelig',
   size,
   title,
   time,
   glossary,
   greenBox,
-}) => (
-  <div className={`ssb-key-figures ${size}${greenBox ? ' green-box' : ''}${className ? ` ${className}` : ''}`}>
-    {icon && <div className={`kf-icon ${size}`}>{icon}</div>}
-    <div>
-      {glossary ? (
-        <Glossary explanation={glossary}>
+}) => {
+  const { changeDirection, changeText, changePeriod, srChangeText } = changes
+  return (
+    <div className={`ssb-key-figures ${size}${greenBox ? ' green-box' : ''}${className ? ` ${className}` : ''}`}>
+      {icon && <div className={`kf-icon ${size}`}>{icon}</div>}
+      <div>
+        {glossary ? (
+          <Glossary explanation={glossary} ariaLabel={title}>
+            <span className='kf-title'>{title}</span>
+          </Glossary>
+        ) : (
           <span className='kf-title'>{title}</span>
-        </Glossary>
-      ) : (
-        <span className='kf-title'>{title}</span>
-      )}
-      <div className='kf-time'>{time}</div>
-      {number ? (
-        <div className='number-section'>
-          <Number size={size}>{number}</Number>
-          <span className='kf-title subtitle'>{numberDescription}</span>
-        </div>
-      ) : (
-        <span className='no-number'>{noNumberText}</span>
-      )}
-      {changes && (
-        <div className='kf-changes'>
-          {changes.changeDirection === 'up' && <ArrowUp className='changes-icon' size={20} />}
-          {changes.changeDirection === 'down' && <ArrowDown className='changes-icon' size={20} />}
-          {changes.changeDirection === 'same' && <Minus className='changes-icon' size={20} />}
-          <span className='changes-text'>{changes.changeText}</span>&nbsp;
-          <span className='changes-periode'>{changes.changePeriod}</span>
-        </div>
-      )}
+        )}
+        <div className='kf-time'>{time}</div>
+        {number ? (
+          <div className='number-section'>
+            <Number size={size}>{number}</Number>
+            <span className='kf-title subtitle'>{numberDescription}</span>
+          </div>
+        ) : (
+          <span className='no-number'>{noNumberText}</span>
+        )}
+        {changes && (
+          <div className='kf-changes'>
+            {changeDirection === 'up' && <ArrowUp className='changes-icon' size={20} aria-hidden='true' />}
+            {changeDirection === 'down' && <ArrowDown className='changes-icon' size={20} aria-hidden='true' />}
+            {changeDirection === 'same' && <Minus className='changes-icon' size={20} aria-hidden='true' />}
+            <span className='changes-text' aria-hidden={srChangeText ? 'true' : 'false'}>
+              {changeText}
+            </span>
+            &nbsp;
+            <span className='changes-periode' aria-hidden={srChangeText ? 'true' : 'false'}>
+              {changePeriod}
+            </span>
+            {srChangeText ? <span className='sr-only'>{srChangeText}</span> : null}
+          </div>
+        )}
+      </div>
     </div>
-  </div>
-)
-
-KeyFigures.defaultProps = {
-  noNumberText: 'Tall ikke tilgjengelig',
+  )
 }
 
 KeyFigures.propTypes = {
@@ -58,6 +63,7 @@ KeyFigures.propTypes = {
     changeDirection: PropTypes.oneOf(['up', 'down', 'same']),
     changeText: PropTypes.string,
     changePeriod: PropTypes.string,
+    srChangeText: PropTypes.string,
   }),
   className: PropTypes.string,
   icon: PropTypes.node,

--- a/src/components/KeyFigures/keyFigures.story.jsx
+++ b/src/components/KeyFigures/keyFigures.story.jsx
@@ -132,9 +132,8 @@ export const WithChanges = () => (
       icon={<HouseIcon />}
       changes={{
         changeDirection: 'down',
-        changeText: '1 %',
+        changeText: 'Ned 1 prosentpoeng',
         changePeriod: 'fra året før',
-        srChangeText: 'Ned 1 % fra året før',
       }}
     />
   </div>

--- a/src/components/KeyFigures/keyFigures.story.jsx
+++ b/src/components/KeyFigures/keyFigures.story.jsx
@@ -19,7 +19,7 @@ export const Large = () => (
       numberDescription='husholdninger'
       time='2018'
       size='large'
-      icon={<HouseIcon alt='house' />}
+      icon={<HouseIcon />}
       glossary={placeholderText}
     />
   </div>
@@ -33,7 +33,7 @@ export const Medium = () => (
       numberDescription='husholdninger'
       time='2018'
       size='medium'
-      icon={<HouseIcon alt='house' />}
+      icon={<HouseIcon />}
     />
   </div>
 )
@@ -46,7 +46,7 @@ export const Small = () => (
       numberDescription='plasser'
       time='2018'
       size='small'
-      icon={<HouseIcon alt='house' />}
+      icon={<HouseIcon />}
     />
   </div>
 )
@@ -86,7 +86,7 @@ export const WithoutNumber = () => (
     numberDescription='plasser'
     time='2018'
     size='small'
-    icon={<HouseIcon alt='house' />}
+    icon={<HouseIcon />}
   />
 )
 
@@ -102,7 +102,7 @@ export const WithChanges = () => (
       numberDescription='husholdninger'
       time='2018'
       size='large'
-      icon={<HouseIcon alt='house' />}
+      icon={<HouseIcon />}
       glossary={placeholderText}
       changes={{
         changeDirection: 'up',
@@ -120,7 +120,7 @@ export const WithChanges = () => (
       numberDescription='husholdninger'
       time='2018'
       size='medium'
-      icon={<HouseIcon alt='house' />}
+      icon={<HouseIcon />}
       changes={{
         changeDirection: 'same',
         changeText: 'Ingen endring',
@@ -137,7 +137,7 @@ export const WithChanges = () => (
       numberDescription='plasser'
       time='2018'
       size='small'
-      icon={<HouseIcon alt='house' />}
+      icon={<HouseIcon />}
       changes={{
         changeDirection: 'down',
         changeText: 'Ned 1 prosentpoeng',

--- a/src/components/KeyFigures/keyFigures.story.jsx
+++ b/src/components/KeyFigures/keyFigures.story.jsx
@@ -76,10 +76,6 @@ export const WithoutIcon = () => (
   </div>
 )
 
-WithoutIcon.story = {
-  name: 'Without icon',
-}
-
 export const WithoutNumber = () => (
   <KeyFigures
     title='Antall plasser i helse- og omsorgsinstitusjoner'
@@ -89,10 +85,6 @@ export const WithoutNumber = () => (
     icon={<HouseIcon />}
   />
 )
-
-WithoutNumber.story = {
-  name: 'Without number',
-}
 
 export const WithChanges = () => (
   <div>
@@ -140,16 +132,13 @@ export const WithChanges = () => (
       icon={<HouseIcon />}
       changes={{
         changeDirection: 'down',
-        changeText: 'Ned 1 prosentpoeng',
+        changeText: '1 %',
         changePeriod: 'fra året før',
+        srChangeText: 'Ned 1 % fra året før',
       }}
     />
   </div>
 )
-
-WithChanges.story = {
-  name: 'With changes',
-}
 
 export const GreenboxVariasjonMedium = () => (
   <KeyFigures
@@ -162,10 +151,6 @@ export const GreenboxVariasjonMedium = () => (
   />
 )
 
-GreenboxVariasjonMedium.story = {
-  name: 'Greenbox variasjon medium',
-}
-
 export const GreenboxVariasjonStor = () => (
   <KeyFigures
     title='Valgdeltagelse ved stortingsvalg'
@@ -176,7 +161,3 @@ export const GreenboxVariasjonStor = () => (
     greenBox
   />
 )
-
-GreenboxVariasjonStor.story = {
-  name: 'Greenbox variasjon stor',
-}

--- a/src/components/KeyFigures/keyFigures.story.jsx
+++ b/src/components/KeyFigures/keyFigures.story.jsx
@@ -139,6 +139,26 @@ export const WithChanges = () => (
   </div>
 )
 
+export const WithChangesAndScreenReaderOnlyText = () => (
+  <div>
+    <KeyFigures
+      number='789 398'
+      title={title}
+      numberDescription='husholdninger'
+      time='2018'
+      size='large'
+      icon={<HouseIcon />}
+      glossary={placeholderText}
+      changes={{
+        changeDirection: 'up',
+        changeText: '1,5%',
+        changePeriod: 'fra året før',
+        srChangeText: 'Oppgang 1,5% fra året før',
+      }}
+    />
+  </div>
+)
+
 export const GreenboxVariasjonMedium = () => (
   <KeyFigures
     title='Valgdeltagelse ved stortingsvalg'

--- a/src/components/KeyFigures/keyFigures.test.jsx
+++ b/src/components/KeyFigures/keyFigures.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { screen, render } from '../../utils/test'
+import { render } from '../../utils/test'
 import { Home } from 'react-feather'
 import KeyFigures from './index'
 

--- a/src/components/KeyFigures/keyFigures.test.jsx
+++ b/src/components/KeyFigures/keyFigures.test.jsx
@@ -15,27 +15,27 @@ describe('KeyFigures component', () => {
         time='2018'
         size='large'
         icon={<Home className='feather-home' />}
-        glossary={'Explain something'}
+        glossary='Explain something'
       />
     )
     expect(asFragment()).toMatchSnapshot()
   })
 
   test('Renders Glossary', () => {
-    const { asFragment } = render(<KeyFigures number='789 398' glossary={'Explain something'} />)
+    const { asFragment } = render(<KeyFigures title={title} number='789 398' glossary='Explain something' />)
     expect(asFragment()).toMatchSnapshot()
   })
   test('Renders time and number', async () => {
-    render(<KeyFigures number='789 398' time='2018' />)
-    expect(screen.getByText('2018')).toBeVisible()
-    expect(screen.getByText('789 398')).toBeVisible()
+    const { getByText } = render(<KeyFigures number='789 398' time='2018' />)
+    expect(getByText('2018')).toBeVisible()
+    expect(getByText('789 398')).toBeVisible()
   })
   test('Render no number text', () => {
-    render(<KeyFigures title='KeyFigure without number' time='2018' noNumberText='Ingen tall' />)
-    expect(screen.getByText('Ingen tall')).toBeVisible()
+    const { getByText } = render(<KeyFigures title='KeyFigure without number' time='2018' noNumberText='Ingen tall' />)
+    expect(getByText('Ingen tall')).toBeVisible()
   })
   test('Render changes', () => {
-    render(
+    const { asFragment, getByText } = render(
       <KeyFigures
         title='KeyFigure without number'
         time='2018'
@@ -46,8 +46,27 @@ describe('KeyFigures component', () => {
         }}
       />
     )
-    expect(screen.getByText('Ned 1 prosentpoeng')).toBeVisible()
-    expect(screen.getByText('fra året før')).toBeVisible()
+    expect(getByText('Ned 1 prosentpoeng')).toBeVisible()
+    expect(asFragment().querySelector('.changes-text')).toHaveAttribute('aria-hidden', 'false')
+    expect(getByText('fra året før')).toBeVisible()
+    expect(asFragment().querySelector('.changes-periode')).toHaveAttribute('aria-hidden', 'false')
+  })
+  test('Render changes with screen reader text', () => {
+    const { asFragment, getByText } = render(
+      <KeyFigures
+        title='KeyFigure without number'
+        time='2018'
+        changes={{
+          changeDirection: 'up',
+          changeText: '30 999 kroner',
+          changePeriod: 'fra året før',
+          srChangeText: 'Oppgang 30 999 kroner fra året før'
+        }}
+      />
+    )
+    expect(getByText('30 999 kroner')).toBeVisible()
+    expect(asFragment().querySelector('.changes-text')).toHaveAttribute('aria-hidden', 'true')
+    expect(getByText('Oppgang 30 999 kroner fra året før')).toHaveClass('sr-only')
   })
   test('Render green box variation', () => {
     const { asFragment } = render(

--- a/src/components/KeyFigures/keyFigures.test.jsx
+++ b/src/components/KeyFigures/keyFigures.test.jsx
@@ -58,15 +58,15 @@ describe('KeyFigures component', () => {
         time='2018'
         changes={{
           changeDirection: 'up',
-          changeText: '30 999 kroner',
+          changeText: '1,5%',
           changePeriod: 'fra året før',
-          srChangeText: 'Oppgang 30 999 kroner fra året før'
+          srChangeText: 'Oppgang 1,5% fra året før',
         }}
       />
     )
-    expect(getByText('30 999 kroner')).toBeVisible()
+    expect(getByText('1,5%')).toBeVisible()
     expect(asFragment().querySelector('.changes-text')).toHaveAttribute('aria-hidden', 'true')
-    expect(getByText('Oppgang 30 999 kroner fra året før')).toHaveClass('sr-only')
+    expect(getByText('Oppgang 1,5% fra året før')).toHaveClass('sr-only')
   })
   test('Render green box variation', () => {
     const { asFragment } = render(


### PR DESCRIPTION
- Alternative screen reader text for key figures with changes (e.g. increase, decrease in x percentage)
- Add aria-label attribute to Glossary since children can be a node. There have been cases where `aria-label="[Object object]"`