### PR TITLE
Update backstage.yaml

### DIFF
--- a/backstage.yaml
+++ b/backstage.yaml
@@ -20,4 +20,3 @@ spec:
   system: SSBNO
   owner: ssbno-developers
   lifecycle: production
----


### PR DESCRIPTION
Removes superflous line separator, possibly preventing the backstage project from correctly reading this spec